### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/app/assets/javascripts/custom.js
+++ b/app/assets/javascripts/custom.js
@@ -294,15 +294,16 @@ document.addEventListener("turbo:load", () => {
 			function createTag(tagText) {
 				const tag = document.createElement("div");
 				tag.classList.add("tag");
-				tag.innerHTML = `${tagText} <span class="tag-close">&#10006;</span>`;
+				tag.textContent = tagText;
 
-				tag.querySelector(".tag-close").addEventListener(
-					"click",
-					function () {
-						tag.remove();
-					}
-				);
+				const closeButton = document.createElement("span");
+				closeButton.classList.add("tag-close");
+				closeButton.innerHTML = "&#10006;";
+				closeButton.addEventListener("click", function () {
+					tag.remove();
+				});
 
+				tag.appendChild(closeButton);
 				tagContainer.appendChild(tag);
 			}
 		});


### PR DESCRIPTION
Potential fix for [https://github.com/jaypatel1s/school-management/security/code-scanning/2](https://github.com/jaypatel1s/school-management/security/code-scanning/2)

To fix the issue, we need to ensure that any user input (`tagInput.value`) is properly escaped before being inserted into the DOM. Instead of using `innerHTML`, which interprets its content as HTML, we can use `textContent` to safely insert plain text. This approach ensures that any special characters in the user input are treated as literal text rather than HTML.

Changes to make:
1. Replace the use of `innerHTML` with `textContent` for the `tagText` portion.
2. Create the close button (`<span class="tag-close">&#10006;</span>`) as a separate DOM element and append it to the tag element programmatically.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
